### PR TITLE
Use the ittapi JLL, and extend the API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,8 @@ uuid = "c9b2f978-7543-4802-ae44-75068f23ee64"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
 version = "0.1.0"
 
+[deps]
+ittapi_jll = "f03c7084-70eb-500e-bb85-e99cbc517f87"
+
 [compat]
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ decrement!(ctr, #=delta=1=#)
 
 ## Attaching to launched processes
 
-If you want to attach a profiler to a running processe, you need to take extra care, as the
+If you want to attach a profiler to a running process, you need to take extra care, as the
 profiler will not be able to override the stubs provided by IntelITT.jl. To work around
 this, you need to specify beforehand which ITT API collector to use. For example, if you
 know you'll be attaching using VTune, find the collector library that VTune uses:
@@ -89,6 +89,20 @@ know you'll be attaching using VTune, find the collector library that VTune uses
 $ INTEL_LIBITTNOTIFY64=~/intel/oneapi/vtune/latest/lib64/runtime/libittnotify_collector.so \
   julia
 ```
+
+
+## Running Julia under VTune
+
+In addition to the instrumentation added using IntelITT.jl, it is also possible to have
+Julia's JIT compiler emit instrumentation that tools like VTune can use. This requires
+starting Julia with the environment variable `ENABLE_JITPROFILING` set to `1`. On older
+versions of Julia, pre-1.9, you also need to re-compile Julia from source with the build
+option `USE_INTEL_JITEVENTS` set to `1`.
+
+More information, including, e.g., a [Intel VTune remote usage
+example](https://juliahpc.github.io/JuliaOnHPCClusters/user_hpcprofiling/intel_vtune/) can
+be found in the [Julia On HPC Clusters](https://juliahpc.github.io/JuliaOnHPCClusters/)
+notes.
 
 
 ## Acknowledgments

--- a/src/IntelITT.jl
+++ b/src/IntelITT.jl
@@ -1,32 +1,8 @@
 module IntelITT
-    # Notes:
-    # Only supports Linux for now.
-    # ENABLE_JITPROFILING=1
-    # INTEL_JIT_BACKWARD_COMPATIBILITY
-    # 0: Resolves inlined call-stacks
-    # 1: Groups at the level of LLVM functions compiled
-    # 
-    # IMPORTANT: Do not use `detach`, doing so causes VTunes
-    #            to not resolve jitted functions.
-    libittnotify::String = ""
-    available() = !isempty(libittnotify)
 
-    function __init__()
-        global libittnotify
-        libittnotify = get(ENV, "INTEL_JIT_PROFILER64", "")
-        if isempty(libittnotify)
-            libittnotify = get(ENV, "INTEL_JIT_PROFILER32", "")
-        end
-        if isempty(libittnotify)
-            libittnotify = get(ENV, "VS_PROFILER", "")
-        end
-        @debug "Using libittnotify" libittnotify
-    end
+using ittapi_jll
 
-    __itt_resume() = ccall((:__itt_resume, libittnotify), Cvoid,())
-    __itt_pause() = ccall((:__itt_pause, libittnotify), Cvoid,())
-    # __itt_detach() = ccall((:__itt_detach, libittnotify), Cvoid,())
-    resume() = available() && __itt_resume()
-    pause() = available() && __itt_pause()
-    # detach() = available() && __itt_detach()
-end # module
+include("wrappers.jl")
+include("utilities.jl")
+
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -34,9 +34,10 @@ macro task(ex...)
 
     quote
         _domain = $(esc(domain))
-        task_begin(_domain, $name)
+        _task = Task(_domain, $name)
+        start(_task)
         # Use Expr(:tryfinally, ...) so we don't introduce a new soft scope.
         # TODO: switch to solution once https://github.com/JuliaLang/julia/pull/39217 is resolved
-        $(Expr(:tryfinally, esc(code), :(task_end(_domain))))
+        $(Expr(:tryfinally, esc(code), :(stop(_task))))
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,5 +1,15 @@
 # high-level utilities
 
+macro profile(ex)
+    quote
+        isactive() || @warn("No ITT collector present. Make sure you have a collector attached to your process, e.g., by running under VTune.")
+        resume()
+        # Use Expr(:tryfinally, ...) so we don't introduce a new soft scope.
+        # TODO: switch to solution once https://github.com/JuliaLang/julia/pull/39217 is resolved
+        $(Expr(:tryfinally, esc(ex), :(pause())))
+    end
+end
+
 macro range(ex...)
     length(ex) >= 2 || error("Usage: IntelITT.@range [domain=...] name::String code")
     name = ex[end-1]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,35 @@
+# high-level utilities
+
+macro range(ex...)
+    length(ex) >= 2 || error("Usage: IntelITT.@range [domain=...] name::String code")
+    name = ex[end-1]
+    code = ex[end]
+    kwargs = ex[1:end-2]
+
+    # handle kwargs
+    domain = nothing
+    for kwarg in kwargs
+        key::Symbol, val = kwarg.args
+        if key === :domain
+            domain = val
+        else
+            error("unknown keyword argument: $key")
+        end
+    end
+    if domain === nothing
+        domain = :(Domain(string($__module__)))
+    end
+
+    domain
+
+    quote
+        _isactive = isactive()
+        if _isactive
+            _domain = $domain
+            task_begin(_domain, $name)
+        end
+        # Use Expr(:tryfinally, ...) so we don't introduce a new soft scope.
+        # TODO: switch to solution once https://github.com/JuliaLang/julia/pull/39217 is resolved
+        $(Expr(:tryfinally, esc(code), :(_isactive && task_end(_domain))))
+    end
+end

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -21,8 +21,18 @@ macro apicall(name, args...)
     end
 end
 
-# XXX: this is observed, not documented
-isactive() = @apicall(:__itt_api_version, Cchar, ()) != 0
+@enum __itt_collection_state::Cint begin
+    __itt_collection_uninitialized = 0          # uninitialized
+    __itt_collection_init_fail = 1              # failed to init
+    __itt_collection_collector_absent = 2       # non work state collector is absent
+    __itt_collection_collector_exists = 3       # work state collector exists
+    __itt_collection_init_successful = 4        # success to init
+end
+
+collection_state() =
+    ccall((:__itt_get_collection_state, ittapi_jll.libittnotify), __itt_collection_state, ())
+
+isactive() = collection_state() == __itt_collection_init_successful
 
 
 #

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -1,0 +1,126 @@
+# library wrappers
+
+export isactive
+
+const __itt_id = NTuple{3, Culonglong}
+const __itt_null = __itt_id((0, 0, 0))
+
+macro apicall(name, args...)
+    slot_name = String(name.value) * "_ptr__3_0"
+    quote
+        slot = cglobal(($(slot_name), ittapi_jll.libittnotify))
+        ptr = unsafe_load(convert(Ptr{Ptr{Cvoid}}, slot))
+        ccall(ptr, ($(map(esc, args)...)))
+    end
+end
+
+# XXX: this is observed, not documented
+isactive() = @apicall(:__itt_api_version, Cchar, ()) != 0
+
+
+#
+# Domains
+#
+
+export Domain, name, isenabled, enable!
+
+struct __itt_domain
+    flags::Cint
+    name::Cstring
+    # don't care about the rest, for now
+end
+
+struct Domain
+    handle::Ptr{__itt_domain}
+end
+Base.unsafe_convert(::Type{Ptr{__itt_domain}}, d::Domain) = d.handle
+
+Domain(name::String) = Domain(@apicall(:__itt_domain_create, Ptr{__itt_domain}, (Cstring,), name))
+
+# XXX: can we do this cleaner?
+function Base.getproperty(d::Domain, name::Symbol)
+    if name in [:flags, :name]
+        d.handle == C_NULL && throw(UndefRefError())
+        return getfield(unsafe_load(d.handle), name)
+    else
+        return getfield(d, name)
+    end
+end
+function Base.setproperty!(d::Domain, name::Symbol, value)
+    if name in [:flags]
+        d.handle == C_NULL && throw(UndefRefError())
+        idx = Base.fieldindex(__itt_domain, name)
+        offset = Base.fieldoffset(__itt_domain, idx)
+        typ = Base.fieldtype(__itt_domain, idx)
+        return unsafe_store!(convert(Ptr{Cint}, d.handle) + offset, value)
+    else
+        return setfield!(d, name, value)
+    end
+end
+
+Base.show(io::IO, d::Domain) = print(io, "Domain(", repr(name(d)), ", enabled=$(isenabled(d)))")
+
+isenabled(d::Domain) = d.flags == 0 ? false : true
+enable!(d::Domain, enable::Bool=true) = d.flags = enable ? 1 : 0
+
+name(d::Domain) = unsafe_string(unsafe_load(d.handle).name)
+
+
+#
+# String handles
+#
+
+export StringHandle
+
+struct __itt_string_handle
+    str::Cstring
+end
+
+struct StringHandle
+    handle::Ptr{__itt_string_handle}
+end
+Base.unsafe_convert(::Type{Ptr{__itt_string_handle}}, s::StringHandle) = s.handle
+
+StringHandle(name::String) =
+    StringHandle(@apicall(:__itt_string_handle_create, Ptr{__itt_string_handle}, (Cstring,), name))
+
+String(s::StringHandle) = unsafe_string(unsafe_load(s.handle).str)
+
+
+#
+# Collection control
+#
+
+export pause, resume, detach
+
+pause() = @apicall(:__itt_pause, Cvoid, ())
+resume() = @apicall(:__itt_resume, Cvoid, ())
+detach() = @apicall(:__itt_detach, Cvoid, ())
+
+
+#
+# Thread Naming
+#
+
+export thread_name!, thread_ignore
+
+thread_name!(name::String) =
+    @apicall(:__itt_thread_set_name, Cvoid, (Cstring,), name)
+
+thread_ignore() = @apicall(:__itt_thread_ignore, Cvoid, ())
+
+
+#
+# Tasks
+#
+
+export task_begin, task_end
+
+function task_begin(domain::Domain, name::String)
+    @apicall(:__itt_task_begin, Cvoid,
+             (Ptr{__itt_domain}, __itt_id, __itt_id, Ptr{__itt_string_handle},),
+             domain, __itt_null, __itt_null, StringHandle(name))
+end
+
+task_end(domain::Domain) =
+    @apicall(:__itt_task_end, Cvoid, (Ptr{__itt_domain},), domain)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -70,7 +70,7 @@ Base.show(io::IO, d::Domain) = print(io, "Domain(", repr(name(d)), ", enabled=$(
 isenabled(d::Domain) = d.flags == 0 ? false : true
 enable!(d::Domain, enable::Bool=true) = d.flags = enable ? 1 : 0
 
-name(d::Domain) = unsafe_string(unsafe_load(d.handle).name)
+name(d::Domain) = unsafe_string(d.name)
 
 
 #

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -317,8 +317,9 @@ end
         ptr = ...
     end
 
-Mark a block of code as allocating memory. The block should return a pointer the allocated
-memory. The `initialized` argument indicates whether the memory is initialized or not.
+Mark a block of code as allocating memory. The block should return a pointer to the
+allocated memory. The `initialized` argument indicates whether the memory is initialized or
+not.
 """
 function alloc(f, h::HeapFunction, size::Integer; initialized::Bool=false)
     alloc_begin(h, size; initialized)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -5,11 +5,18 @@ export isactive
 const __itt_id = NTuple{3, Culonglong}
 const __itt_null = __itt_id((0, 0, 0))
 
-macro apicall(name, args...)
-    slot_name = String(name.value) * "_ptr__3_0"
+@inline lookup_function(name::Symbol) = _lookup_function(Val(name))
+@generated function _lookup_function(::Val{name}) where {name}
+    slot_name = String(name) * "_ptr__3_0"
     quote
         slot = cglobal(($(slot_name), ittapi_jll.libittnotify))
-        ptr = unsafe_load(convert(Ptr{Ptr{Cvoid}}, slot))
+        unsafe_load(convert(Ptr{Ptr{Cvoid}}, slot))
+    end
+end
+
+macro apicall(name, args...)
+    quote
+        ptr = lookup_function($(name))
         ccall(ptr, ($(map(esc, args)...)))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,56 @@
-using IntelITT
+using IntelITT, Test
+
+@testset "IntelITT" begin
+
+IntelITT.isactive() ||
+    @warn "No ITT collector present. For complete test coverage, make sure you have a collector attached to your process, e.g., by running under VTune."
+inactive = !IntelITT.isactive()
+
+let d = Domain("test")
+    @test name(d) == "test" skip=inactive
+
+    enable!(d, true)
+    @test isenabled(d) skip=inactive
+
+    enable!(d, false)
+    @test !isenabled(d)
+end
+
+let str = StringHandle("test")
+    @test String(str) == "test" skip=inactive
+end
+
+resume()
+pause()
+
+thread_name!("test")
+thread_ignore()
+
+let d = Domain("test")
+    task_begin(d, "test")
+    task_end(d)
+end
+
+let ev = Event("test")
+    start(ev)
+    stop(ev)
+end
+
+let ctr = Counter{UInt64}("test", "test")
+    ctr[] = 0
+    increment!(ctr)
+    increment!(ctr, 2)
+    decrement!(ctr)
+    decrement!(ctr, 2)
+end
+
+let ctr = Counter{Float64}("test", "test")
+    ctr[] = 0.0
+    @test_throws MethodError increment!(ctr)
+    @test_throws MethodError increment!(ctr, 2.0)
+    @test_throws MethodError decrement!(ctr)
+    @test_throws MethodError decrement!(ctr, 2.0)
+end
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,9 @@ thread_name!("test")
 thread_ignore()
 
 let d = Domain("test")
-    task_begin(d, "test")
-    task_end(d)
+    t = IntelITT.Task(d, "test")
+    start(t)
+    stop(t)
     IntelITT.@task domain=d "test" begin end
 end
 IntelITT.@task "test" begin end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,7 @@ using IntelITT, Test
 
 @testset "IntelITT" begin
 
-IntelITT.isactive() ||
-    @warn "No ITT collector present. For complete test coverage, make sure you have a collector attached to your process, e.g., by running under VTune."
+# some tests don't work without an active collector
 inactive = !IntelITT.isactive()
 
 let d = Domain("test")
@@ -22,6 +21,7 @@ end
 
 resume()
 pause()
+IntelITT.@collect begin end
 
 thread_name!("test")
 thread_ignore()
@@ -29,7 +29,9 @@ thread_ignore()
 let d = Domain("test")
     task_begin(d, "test")
     task_end(d)
+    IntelITT.@task domain=d "test" begin end
 end
+IntelITT.@task "test" begin end
 
 let ev = Event("test")
     start(ev)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,5 +52,31 @@ let ctr = Counter{Float64}("test", "test")
     @test_throws MethodError decrement!(ctr, 2.0)
 end
 
+let h = HeapFunction("test", "test")
+    alloc_begin(h, 0)
+    alloc_end(h, C_NULL, 0)
+
+    alloc(h, 0) do size
+        @test size == 0
+        C_NULL
+    end
+
+    free_begin(h, C_NULL)
+    free_end(h, C_NULL)
+
+    free(h, C_NULL) do ptr
+        @test ptr == C_NULL
+        nothing
+    end
+
+    realloc_begin(h, C_NULL, 0)
+    realloc_end(h, C_NULL, C_NULL, 0)
+
+    realloc(h, C_NULL, 0) do ptr, new_size
+        @test ptr == C_NULL
+        @test new_size == 0
+        C_NULL
+    end
+end
 
 end


### PR DESCRIPTION
This PR reworks how IntelITT.jl interfaces with the ITT APIs, by using the shared library from ittapi_jll. Instead of inspecting the environment to discover an ITT implementation library, it relies on the fact that an installed collector will override the stub implementations provided by libittnotify.so.

For example, without VTune:

```julia
❯ julia
julia> using IntelITT

julia> slot = cglobal(("__itt_api_version_ptr__3_0", IntelITT.ittapi_jll.libittnotify))
Ptr{Nothing} @0x00007f713e812b10

julia> fun = unsafe_load(convert(Ptr{Ptr{Nothing}}, slot))
Ptr{Nothing} @0x00007f713e60b640

julia> ccall(fun, Cchar, ())
0
```

... whereas running under VTune:

```julia
❯ ~/intel/oneapi/vtune/latest/bin64/vtune -collect hotspots -start-paused julia

julia> using IntelITT

julia> slot = cglobal(("__itt_api_version_ptr__3_0", IntelITT.ittapi_jll.libittnotify))
Ptr{Nothing} @0x00007f87c5212b10

julia> fun = unsafe_load(convert(Ptr{Ptr{Nothing}}, slot))
Ptr{Nothing} @0x00007f87c500b640

julia> ccall(fun, Cchar, ())
-32
```

A macro makes this easier:

```julia
julia> IntelITT.@apicall(:__itt_api_version, Cchar, ())
-32
```

This is also how the upstream Rust wrapper works.

---

I also added some additional wrappers and macros to make it behave a little like NVTX.jl.

See the updated README: https://github.com/maleadt/IntelITT.jl/blob/rework/README.md